### PR TITLE
Netboxv4

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,368 @@
+# NetBox PowerDNS Sync - Architecture & Documentation
+
+> Technical documentation for developers working on this plugin.
+
+## Overview
+
+This plugin synchronizes DNS records between NetBox and PowerDNS. It creates forward (A/AAAA) and reverse (PTR) DNS records based on IP addresses configured in NetBox.
+
+### Key Concepts
+
+- **Zone**: A DNS zone (e.g., `example.com.`) that defines which IP addresses should have DNS records created
+- **ApiServer**: A PowerDNS API endpoint that the plugin communicates with
+- **Naming Method**: A strategy for generating FQDNs from NetBox objects (IP, Device, VM, FHRP Group)
+- **Sync Job**: A background task that compares NetBox records with PowerDNS and creates/deletes records as needed
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         NetBox                                   │
+│  ┌─────────┐  ┌─────────┐  ┌─────────────┐  ┌───────────────┐   │
+│  │ Devices │  │   VMs   │  │ FHRP Groups │  │  IP Addresses │   │
+│  └────┬────┘  └────┬────┘  └──────┬──────┘  └───────┬───────┘   │
+│       │            │              │                  │           │
+│       └────────────┴──────────────┴──────────────────┘           │
+│                              │                                   │
+│                    ┌─────────▼─────────┐                         │
+│                    │   Sync Job        │                         │
+│                    │  (jobs.py)        │                         │
+│                    └─────────┬─────────┘                         │
+│                              │                                   │
+│              ┌───────────────┼───────────────┐                   │
+│              │               │               │                   │
+│     ┌────────▼────────┐ ┌────▼────┐ ┌───────▼───────┐           │
+│     │  Naming Methods │ │  Zone   │ │   ApiServer   │           │
+│     │   (naming.py)   │ │ Matching│ │   Connection  │           │
+│     └─────────────────┘ └─────────┘ └───────┬───────┘           │
+└─────────────────────────────────────────────┼───────────────────┘
+                                              │
+                                    ┌─────────▼─────────┐
+                                    │    PowerDNS API   │
+                                    │   (REST API)      │
+                                    └───────────────────┘
+```
+
+## Models
+
+### ApiServer (`models.py`)
+
+Represents a PowerDNS API endpoint.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | CharField | Unique name for the server |
+| `api_url` | URLField | Base URL (e.g., `http://pdns:8081/api/v1`) |
+| `api_token` | CharField | API authentication token |
+| `enabled` | BooleanField | Whether this server is active |
+
+**Important**: The `api_url` field has a unique constraint.
+
+### Zone (`models.py`)
+
+Represents a DNS zone to sync.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | CharField | Zone name with trailing dot (e.g., `example.com.`) |
+| `enabled` | BooleanField | Whether sync is enabled |
+| `api_servers` | ManyToManyField | PowerDNS servers to sync to |
+| `default_ttl` | IntegerField | Default TTL for records |
+| `is_default` | BooleanField | Use as fallback zone (only one allowed) |
+| `naming_ip_method` | CharField | Class path for IP naming strategy |
+| `naming_device_method` | CharField | Class path for Device/VM naming strategy |
+| `naming_fgrpgroup_method` | CharField | Class path for FHRP Group naming strategy |
+| `match_*` | Various | Tag/role matching for zone selection |
+
+**Constraints**:
+- Zone name must end with a dot (`.`)
+- Only one zone can be `is_default=True`
+- At least one naming method must be configured
+- Reverse zones cannot be default
+
+### Zone Matching
+
+The plugin uses these criteria to match IPs to zones (in order):
+
+1. `match_ipaddress_tags` - Tags on the IPAddress
+2. `match_interface_tags` - Tags on the Interface/VMInterface
+3. `match_device_tags` - Tags on the Device/VirtualMachine
+4. `match_fhrpgroup_tags` - Tags on the FHRP Group
+5. `match_device_roles` - Device/VM role
+6. `is_default=True` - Fallback zone
+
+## Naming Methods (`naming.py`)
+
+Naming methods determine how FQDNs are generated from NetBox objects.
+
+### Available Methods
+
+| Class | Description | Example Output |
+|-------|-------------|----------------|
+| `NamingIpDnsName` | Use IPAddress.dns_name field | `server01.example.com.` |
+| `NamingIpReverse` | Use PTR format (without arpa) | `1.0.168.192.` |
+| `NamingDeviceName` | Device/VM name only | `server01.` |
+| `NamingDeviceByInterface` | `interface.device` format | `eth0.server01.` |
+| `NamingDeviceByInterfacePrimary` | `interface-device` for non-primary IPs | `eth0-server01.` |
+| `NamingFGRPGroupName` | FHRP Group name | `vrrp-group1.` |
+
+### How Naming Works
+
+```python
+# In naming.py
+def generate_fqdn(ip: IPAddress, zone: Zone) -> str | None:
+    for method_attr in ['naming_ip_method', 'naming_device_method', 'naming_fgrpgroup_method']:
+        method = getattr(zone, method_attr, None)
+        if method:
+            klass = _load_class(method)  # Dynamic class loading
+            if klass is None:
+                continue  # IMPORTANT: Skip if class not found
+            naming_method = klass(ip, zone)
+            fqdn = naming_method.make_fqdn()
+            if fqdn:
+                return fqdn
+    return None
+```
+
+**Important**: Methods are tried in order. First successful FQDN wins.
+
+## Sync Jobs (`jobs.py`)
+
+### Job Classes
+
+- `PowerdnsTask` - Base class with logging and utilities
+- `PowerdnsTaskIP` - Single IP sync (triggered by signals)
+- `PowerdnsTaskFullSync` - Full zone sync
+
+### Full Sync Flow
+
+```
+run_full_sync(job, zone_id)
+    │
+    ├── Validate zone exists and is enabled
+    │
+    ├── load_netbox_records()
+    │   ├── get_addresses (property) - Find matching IPs
+    │   ├── For each IP:
+    │   │   ├── make_fqdn() - Generate FQDN using naming methods
+    │   │   ├── Create forward record if zone matches
+    │   │   └── Create reverse record if reverse zone
+    │   └── Return set of DnsRecord objects
+    │
+    ├── load_pdns_records()
+    │   ├── get_pdns_servers_for_zone() - Get enabled API servers
+    │   ├── Fetch records from PowerDNS API
+    │   └── Return set of DnsRecord objects
+    │
+    ├── Calculate diff:
+    │   ├── to_delete = pdns_records - netbox_records
+    │   └── to_create = netbox_records - pdns_records
+    │
+    └── Apply changes to PowerDNS
+```
+
+### Critical Code Paths
+
+#### Getting API Servers for a Zone
+
+```python
+# jobs.py - CORRECT implementation
+def get_pdns_servers_for_zone(self, zone_name: str) -> list[ApiServer]:
+    if not zone_name:
+        return []
+    zone = Zone.objects.filter(name=zone_name).first()
+    if not zone:
+        return []
+    # Use .filter(enabled=True) NOT .enabled()
+    # ManyToManyField RelatedManagers don't inherit QuerySet methods
+    return zone.api_servers.filter(enabled=True)
+```
+
+**WARNING**: Do NOT use `zone.api_servers.enabled()` - the `.enabled()` method from `EnabledQuerySet` is not available on ManyToMany RelatedManagers.
+
+## Common Pitfalls & Constraints
+
+### 1. ManyToMany QuerySet Methods
+
+```python
+# WRONG - Will fail with AttributeError
+zone.api_servers.enabled().all()
+
+# CORRECT
+zone.api_servers.filter(enabled=True)
+```
+
+### 2. Zone Names Must End with Dot
+
+```python
+# WRONG
+zone.name = "example.com"
+
+# CORRECT
+zone.name = "example.com."
+```
+
+### 3. Naming Methods Must Be Valid Class Paths
+
+```python
+# WRONG - Will silently fail
+zone.naming_device_method = "device_name"
+
+# CORRECT
+zone.naming_device_method = "netbox_powerdns_sync.naming.NamingDeviceName"
+```
+
+### 4. FQDN Can Be None
+
+Always check if `self.fqdn` is not None before using it:
+
+```python
+# WRONG
+if self.forward_zone and self.forward_zone == self.zone:
+    name = self.fqdn.replace(...)  # Fails if fqdn is None
+
+# CORRECT
+if self.forward_zone and self.forward_zone == self.zone and self.fqdn:
+    name = self.fqdn.replace(...)
+```
+
+### 5. IPAddress.address Type
+
+In NetBox v4, `IPAddress.address` can be a string during object creation. Always refresh from DB before accessing `.family` or `.version`:
+
+```python
+ip.refresh_from_db()
+if ip.family == 4:
+    # Safe to use
+```
+
+### 6. Job Enqueue Without Instance
+
+In NetBox v4, jobs cannot be attached to plugin model instances by default:
+
+```python
+# WRONG - ValidationError
+Job.enqueue(func, instance=zone, ...)
+
+# CORRECT
+Job.enqueue(func, zone_id=zone.pk, ...)
+```
+
+## Management Commands
+
+### bootstrap_e2e
+
+Creates test data for e2e testing.
+
+```bash
+# Empty mode (fresh database) - uses example.com
+python manage.py bootstrap_e2e --empty --sync
+
+# Data mode (existing data) - uses test-e2e.local
+python manage.py bootstrap_e2e --sync
+
+# With cleanup
+python manage.py bootstrap_e2e --empty --cleanup --sync
+
+# Dry run
+python manage.py bootstrap_e2e --empty --dry-run -v 2
+```
+
+**Objects Created**:
+- 3 Devices with interfaces and IPs
+- 3 VMs with interfaces and IPs
+- 3 standalone IPs with dns_name
+- Zone with proper naming methods
+- Link to existing API Server
+
+## File Structure
+
+```
+netbox_powerdns_sync/
+├── __init__.py          # PluginConfig
+├── models.py            # ApiServer, Zone models
+├── jobs.py              # Sync job classes (PowerdnsTaskFullSync, etc.)
+├── naming.py            # FQDN generation strategies
+├── signals.py           # Django signals for auto-sync
+├── choices.py           # Naming method choices for forms
+├── constants.py         # FAMILY_TYPES, PTR_TYPE, etc.
+├── querysets.py         # EnabledQuerySet, ZoneQuerySet
+├── record.py            # DnsRecord dataclass
+├── utils.py             # Helper functions
+├── validators.py        # Zone name validators
+├── filtersets.py        # Django filter sets
+├── tables.py            # Django tables
+├── urls.py              # URL routing
+├── navigation.py        # NetBox menu integration
+├── forms/               # Django forms
+├── views/               # Django views
+├── api/                 # REST API serializers and views
+├── templates/           # HTML templates
+├── migrations/          # Database migrations
+└── management/
+    └── commands/
+        └── bootstrap_e2e.py  # E2E test bootstrap command
+```
+
+## Debugging Tips
+
+### Check Zone Configuration
+
+```python
+from netbox_powerdns_sync.models import Zone
+
+zone = Zone.objects.first()
+print(f"Zone: {zone.name}")
+print(f"Enabled: {zone.enabled}")
+print(f"API Servers: {list(zone.api_servers.filter(enabled=True))}")
+print(f"Naming IP: {zone.naming_ip_method}")
+print(f"Naming Device: {zone.naming_device_method}")
+```
+
+### Test FQDN Generation
+
+```python
+from ipam.models import IPAddress
+from netbox_powerdns_sync.models import Zone
+from netbox_powerdns_sync.naming import generate_fqdn
+
+ip = IPAddress.objects.first()
+zone = Zone.objects.first()
+fqdn = generate_fqdn(ip, zone)
+print(f"IP: {ip} -> FQDN: {fqdn}")
+```
+
+### Test API Server Connection
+
+```python
+from netbox_powerdns_sync.models import ApiServer
+
+server = ApiServer.objects.first()
+api = server.api
+if api:
+    zones = api.get_zones()
+    print(f"PowerDNS zones: {[z.name for z in zones]}")
+```
+
+### Check Worker Logs
+
+```bash
+docker compose -p prod-dev-v4 logs -f netbox-worker
+```
+
+## NetBox v4 Migration Notes
+
+Key changes from v3 to v4:
+
+1. **Imports**: `extras.plugins` → `netbox.plugins`
+2. **ContentType**: Now `ObjectType` from `core.models`
+3. **count_related**: Moved to `utilities.query`
+4. **normalize_querydict**: Moved to `utilities.querydict`
+5. **get_plugin_config**: Moved to `netbox.plugins.utils`
+6. **Cluster.site**: Removed - site is now on VM directly
+7. **Job.enqueue**: Cannot use `instance` for plugin models
+
+## Dependencies
+
+- `python-powerdns>=2.1.0` - PowerDNS API client
+- `django>=5.0` - Django framework (NetBox v4 requirement)

--- a/netbox_powerdns_sync/__init__.py
+++ b/netbox_powerdns_sync/__init__.py
@@ -1,4 +1,4 @@
-from extras.plugins import PluginConfig
+from netbox.plugins import PluginConfig
 from .version import __version__
 
 
@@ -10,7 +10,7 @@ class NetBoxPowerdnsSyncConfig(PluginConfig):
     author = "Matej Vadnjal"
     author_email = "matej.vadnjal@arnes.si"
     base_url = "powerdns-sync"
-    min_version = "3.6.0"
+    min_version = "4.4.0"
     default_settings = {
         "ttl_custom_field": None,
         "powerdns_managed_record_comment": "netbox-powerdns-sync",

--- a/netbox_powerdns_sync/api/serializers.py
+++ b/netbox_powerdns_sync/api/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
-from netbox.api.serializers import NetBoxModelSerializer, NestedTagSerializer
-from dcim.api.serializers import NestedDeviceRoleSerializer
+from netbox.api.serializers import NetBoxModelSerializer
+from extras.api.serializers import TagSerializer
+from dcim.api.serializers import DeviceRoleSerializer
 
 from .nested_serializers import *
 from ..models import ApiServer, Zone
@@ -26,11 +27,11 @@ class ZoneSerializer(NetBoxModelSerializer):
     )
     is_reverse = serializers.BooleanField(read_only=True)
     api_servers = NestedApiServerSerializer(many=True, required=True)
-    match_ipaddress_tags = NestedTagSerializer(many=True, required=False)
-    match_interface_tags = NestedTagSerializer(many=True, required=False)
-    match_device_tags = NestedTagSerializer(many=True, required=False)
-    match_fhrpgroup_tags = NestedTagSerializer(many=True, required=False)
-    match_device_roles = NestedDeviceRoleSerializer(many=True, required=False)
+    match_ipaddress_tags = TagSerializer(many=True, required=False)
+    match_interface_tags = TagSerializer(many=True, required=False)
+    match_device_tags = TagSerializer(many=True, required=False)
+    match_fhrpgroup_tags = TagSerializer(many=True, required=False)
+    match_device_roles = DeviceRoleSerializer(many=True, required=False)
 
     class Meta:
         model = Zone

--- a/netbox_powerdns_sync/forms/model_forms.py
+++ b/netbox_powerdns_sync/forms/model_forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.core.exceptions import ValidationError
 from netbox.forms import NetBoxModelForm
+from utilities.forms.rendering import FieldSet
 from utilities.forms import add_blank_choice
 
 from ..choices import NamingDeviceChoices, NamingFgrpGroupChoices, NamingIpChoices
@@ -16,25 +17,13 @@ __all__ = (
 class ApiServerForm(NetBoxModelForm):
     """
     Form for creating or updating an API server.
-
-    Args:
-        self: The instance of the form.
-
-    Attributes:
-        fieldsets (tuple): The fieldsets for the form.
-
-    Meta:
-        model (ApiServer): The model associated with the form.
-        fields (list): The fields to include in the form.
-
     """
 
-
-class ApiServerForm(NetBoxModelForm):
     fieldsets = (
-        ("API Server", (
+        FieldSet(
             "name", "api_url", "api_token", "description", "enabled", "tags",
-        )),
+            name="API Server"
+        ),
     )
 
     class Meta:
@@ -65,19 +54,22 @@ class ZoneForm(NetBoxModelForm):
     )
 
     fieldsets = (
-        ("DNS Zone", (
+        FieldSet(
             "name", "description", "enabled", "api_servers", "is_default",
             "default_ttl",
-        )),
-        ("Matchers", (
+            name="DNS Zone"
+        ),
+        FieldSet(
             "match_ipaddress_tags", "match_interface_tags",
             "match_device_tags", "match_fhrpgroup_tags", "match_device_roles",
             "match_interface_mgmt_only",
-        )),
-        ("Naming methods", (
+            name="Matchers"
+        ),
+        FieldSet(
             "naming_ip_method", "naming_device_method", "naming_fgrpgroup_method",
-        )),
-        ("General", ("tags",)),
+            name="Naming methods"
+        ),
+        FieldSet("tags", name="General"),
     )
 
     class Meta:

--- a/netbox_powerdns_sync/jobs.py
+++ b/netbox_powerdns_sync/jobs.py
@@ -262,6 +262,7 @@ class PowerdnsTaskIP(PowerdnsTask):
             self.log_info(
                 f"No FQDN could be determined for IP:{self.ip}. Skipping"
             )
+            return
 
         reverse_fqdn = self.make_reverse_domain()
         self.reverse_zone = Zone.get_best_zone(reverse_fqdn)
@@ -293,8 +294,9 @@ class PowerdnsTaskFullSync(PowerdnsTask):
     def __init__(self, job: Job, zone_id: int = None) -> None:
         super().__init__(job)
         # Support both old way (job.object) and new way (zone_id parameter)
+        # Use filter().first() instead of get() to avoid DoesNotExist exception
         if zone_id:
-            self.zone: Zone = Zone.objects.get(pk=zone_id)
+            self.zone: Zone = Zone.objects.filter(pk=zone_id).first()
         else:
             self.zone: Zone = job.object
 

--- a/netbox_powerdns_sync/jobs.py
+++ b/netbox_powerdns_sync/jobs.py
@@ -91,8 +91,10 @@ class PowerdnsTask(JobLoggingMixin):
     def get_pdns_servers_for_zone(self, zone_name: str) -> list[ApiServer]:
         if not zone_name:
             return []
-        zone = Zone.objects.get(name=zone_name)
-        return zone.api_servers.enabled().all()
+        zone = Zone.objects.filter(name=zone_name).first()
+        if not zone:
+            return []
+        return zone.api_servers.filter(enabled=True)
 
     def add_to_output(self, row):
         if not self.job.data:
@@ -230,7 +232,7 @@ class PowerdnsTaskIP(PowerdnsTask):
 
         if not self.forward_zone:
             self.log_info(f"No matching forward zone found for IP:{self.ip}. Skipping")
-            pass
+            return
         else:
             self.log_info(f"Found matching forward zone to be {self.forward_zone}")
 
@@ -238,26 +240,15 @@ class PowerdnsTaskIP(PowerdnsTask):
             self.log_info(
                 f"No FQDN could be determined for IP:{self.ip} (zone:{self.forward_zone}). Skipping"
             )
+            return
 
-        reverse_fqdn = self.make_reverse_domain()
-        self.log_debug(f"Reverse FQDN: {reverse_fqdn}")
-        self.reverse_zone = Zone.get_best_zone(str(reverse_fqdn))
-        if not self.reverse_zone:
-            self.log_info(f"No matching reverse zone for {self.ip} ({self.fqdn}). Skipping")
-            pass
-
-        self.log_debug(
-            f"Reverse zone found for IP:{self.ip} (zone:{self.reverse_zone})"
-        )
         name = self.fqdn.replace(self.forward_zone.name, "").rstrip(".")
-        fqdn = generate_fqdn(self.ip, self.reverse_zone)
-        custom_domain = get_custom_domain(self.ip)
 
         dns_record = DnsRecord(
             name=name,
             dns_type=FAMILY_TYPES[self.ip.family],
             data=str(self.ip.address.ip),
-            ttl=get_ip_ttl(self.ip) or self.reverse_zone.default_ttl,
+            ttl=get_ip_ttl(self.ip) or self.forward_zone.default_ttl,
             zone_name=self.forward_zone.name,
         )
         self.log_info(f"Forward record: {dns_record}")
@@ -267,14 +258,9 @@ class PowerdnsTaskIP(PowerdnsTask):
     def create_reverse(self) -> None:
         self.make_fqdn()
 
-        if not self.forward_zone:
-            self.log_info(f"No matching forward zone found for IP:{ip}. Skipping")
-        else:
-            self.log_info(f"Found matching forward zone to be {self.forward_zone}")
-
         if not self.fqdn:
             self.log_info(
-                f"No FQDN could be determined for IP:{ip} (zone:{self.forward_zone}). Skipping"
+                f"No FQDN could be determined for IP:{self.ip}. Skipping"
             )
 
         reverse_fqdn = self.make_reverse_domain()
@@ -304,15 +290,24 @@ class PowerdnsTaskIP(PowerdnsTask):
 
 
 class PowerdnsTaskFullSync(PowerdnsTask):
-    def __init__(self, job: Job) -> None:
+    def __init__(self, job: Job, zone_id: int = None) -> None:
         super().__init__(job)
-        self.zone: Zone = job.object
+        # Support both old way (job.object) and new way (zone_id parameter)
+        if zone_id:
+            self.zone: Zone = Zone.objects.get(pk=zone_id)
+        else:
+            self.zone: Zone = job.object
 
     @classmethod
-    def run_full_sync(cls, job: Job, *args, **kwargs) -> None:
-        task = cls(job)
+    def run_full_sync(cls, job: Job, zone_id: int = None, *args, **kwargs) -> None:
+        task = cls(job, zone_id=zone_id)
 
         try:
+            if not task.zone:
+                task.log_failure(f"Zone not found (zone_id={zone_id})")
+                task.job.terminate(status=JobStatusChoices.STATUS_ERRORED)
+                return
+
             task.log_debug(f"Starting sync for zone {task.zone}")
             task.job.start()
             if not task.zone.enabled:
@@ -365,7 +360,7 @@ class PowerdnsTaskFullSync(PowerdnsTask):
             new_scheduled_time = job.scheduled + timedelta(minutes=job.interval)
             Job.enqueue(
                 cls.run_full_sync,
-                instance=job.object,
+                zone_id=task.zone.pk,
                 name=job.name,
                 user=job.user,
                 schedule_at=new_scheduled_time,
@@ -463,7 +458,7 @@ class PowerdnsTaskFullSync(PowerdnsTask):
             self.log_debug(f"Forward FQDN: {self.fqdn}")
             self.log_debug(f"Self zone: {self.zone}")
 
-            if self.forward_zone and self.forward_zone == self.zone:
+            if self.forward_zone and self.forward_zone == self.zone and self.fqdn:
                 name = self.fqdn.replace(self.forward_zone.name, "").rstrip(".")
                 self.log_info(
                     f"Forward zone is matching self.zone, creating forward record for {name}"

--- a/netbox_powerdns_sync/management/commands/bootstrap_e2e.py
+++ b/netbox_powerdns_sync/management/commands/bootstrap_e2e.py
@@ -1,0 +1,454 @@
+"""
+Bootstrap command for PowerDNS Sync e2e tests.
+
+Creates all necessary objects in NetBox to test PowerDNS synchronization.
+Detects if running in "empty" mode (fresh database) or with existing data.
+
+Usage:
+    python manage.py bootstrap_e2e [--empty] [--sync] [--cleanup]
+
+Options:
+    --empty     Force empty mode (use example.com domain)
+    --sync      Trigger a sync after creating objects
+    --cleanup   Remove all test objects before creating new ones
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.auth import get_user_model
+from django.db import transaction
+
+from dcim.models import Site, Manufacturer, DeviceRole, DeviceType, Device, Interface
+from ipam.models import IPAddress
+from virtualization.models import Cluster, ClusterType, VirtualMachine, VMInterface
+from core.models import Job
+
+from netbox_powerdns_sync.models import ApiServer, Zone
+from netbox_powerdns_sync.jobs import PowerdnsTaskFullSync
+
+
+class Command(BaseCommand):
+    help = "Bootstrap NetBox with test data for PowerDNS Sync e2e tests"
+
+    # Configuration for empty mode (example.com)
+    EMPTY_CONFIG = {
+        "domain": "example.com.",
+        "prefix": "e2e",
+        "network": "10.100.0",
+        "api_server": {
+            "name": "E2E PDNS Server",
+            "api_url": "http://pdns-auth:8081/api/v1",
+            "api_token": "secret",
+        },
+    }
+
+    # Configuration for non-empty mode (different domain to avoid conflicts)
+    DATA_CONFIG = {
+        "domain": "test-e2e.local.",
+        "prefix": "e2e-test",
+        "network": "10.200.0",
+        "api_server": {
+            "name": "E2E Test PDNS",
+            "api_url": "http://pdns-auth:8081/api/v1",
+            "api_token": "secret",
+        },
+    }
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--empty",
+            action="store_true",
+            help="Force empty mode (use example.com domain)",
+        )
+        parser.add_argument(
+            "--sync",
+            action="store_true",
+            help="Trigger a sync after creating objects",
+        )
+        parser.add_argument(
+            "--cleanup",
+            action="store_true",
+            help="Remove all test objects before creating new ones",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be created without making changes",
+        )
+
+    def handle(self, *args, **options):
+        self.verbosity = options.get("verbosity", 1)
+        self.dry_run = options.get("dry_run", False)
+
+        # Detect mode
+        is_empty = options["empty"] or self._detect_empty_mode()
+        config = self.EMPTY_CONFIG if is_empty else self.DATA_CONFIG
+
+        mode_str = "EMPTY" if is_empty else "DATA"
+        self.stdout.write(f"\n{'='*60}")
+        self.stdout.write(f"PowerDNS Sync E2E Bootstrap - Mode: {mode_str}")
+        self.stdout.write(f"Domain: {config['domain']}")
+        self.stdout.write(f"{'='*60}\n")
+
+        if self.dry_run:
+            self.stdout.write(self.style.WARNING("DRY RUN - No changes will be made\n"))
+
+        # Cleanup if requested
+        if options["cleanup"]:
+            self._cleanup(config)
+
+        # Create objects
+        with transaction.atomic():
+            if self.dry_run:
+                # Don't commit in dry-run mode
+                transaction.set_rollback(True)
+
+            api_server = self._create_api_server(config)
+            zone = self._create_zone(config, api_server)
+            site = self._create_site(config)
+            manufacturer = self._create_manufacturer(config)
+            device_role = self._create_device_role(config)
+            device_type = self._create_device_type(config, manufacturer)
+
+            # Create devices with IPs
+            devices = self._create_devices(config, site, device_role, device_type)
+
+            # Create VMs with IPs
+            vms = self._create_vms(config, site)
+
+            # Create standalone IPs with dns_name
+            standalone_ips = self._create_standalone_ips(config)
+
+        # Summary
+        self.stdout.write(f"\n{'='*60}")
+        self.stdout.write(self.style.SUCCESS("Bootstrap completed!"))
+        self.stdout.write(f"{'='*60}")
+        self.stdout.write(f"  Zone: {zone.name if not self.dry_run else config['domain']}")
+        self.stdout.write(f"  Devices: {len(devices)}")
+        self.stdout.write(f"  VMs: {len(vms)}")
+        self.stdout.write(f"  Standalone IPs: {len(standalone_ips)}")
+
+        # Trigger sync if requested
+        if options["sync"] and not self.dry_run:
+            self._trigger_sync(zone)
+
+    def _detect_empty_mode(self):
+        """Detect if database is mostly empty (fresh install)."""
+        device_count = Device.objects.count()
+        vm_count = VirtualMachine.objects.count()
+        ip_count = IPAddress.objects.count()
+
+        total = device_count + vm_count + ip_count
+        is_empty = total < 10
+
+        if self.verbosity >= 2:
+            self.stdout.write(f"Detection: {device_count} devices, {vm_count} VMs, {ip_count} IPs")
+            self.stdout.write(f"Mode detected: {'EMPTY' if is_empty else 'DATA'}")
+
+        return is_empty
+
+    def _cleanup(self, config):
+        """Remove test objects created by previous runs."""
+        prefix = config["prefix"]
+        domain = config["domain"]
+
+        self.stdout.write(self.style.WARNING(f"Cleaning up objects with prefix '{prefix}'..."))
+
+        if self.dry_run:
+            self.stdout.write("  Would delete test objects")
+            return
+
+        # Delete in reverse order of dependencies
+        IPAddress.objects.filter(dns_name__endswith=domain.rstrip(".")).delete()
+        VMInterface.objects.filter(virtual_machine__name__startswith=prefix).delete()
+        VirtualMachine.objects.filter(name__startswith=prefix).delete()
+        Interface.objects.filter(device__name__startswith=prefix).delete()
+        Device.objects.filter(name__startswith=prefix).delete()
+        DeviceType.objects.filter(model__startswith=prefix).delete()
+        DeviceRole.objects.filter(name__startswith=prefix).delete()
+        Manufacturer.objects.filter(name__startswith=prefix).delete()
+        Cluster.objects.filter(name__startswith=prefix).delete()
+        ClusterType.objects.filter(name__startswith=prefix).delete()
+        Site.objects.filter(name__startswith=prefix).delete()
+        Zone.objects.filter(name=domain).delete()
+        ApiServer.objects.filter(name=config["api_server"]["name"]).delete()
+
+        self.stdout.write(self.style.SUCCESS("  Cleanup completed"))
+
+    def _create_api_server(self, config):
+        """Create or get PowerDNS API Server."""
+        api_config = config["api_server"]
+
+        # First try to find by URL (unique constraint)
+        try:
+            api_server = ApiServer.objects.get(api_url=api_config["api_url"])
+            self.stdout.write(f"  API Server: {api_server.name} (Found existing by URL)")
+            return api_server
+        except ApiServer.DoesNotExist:
+            pass
+
+        # Then try to find by name or create
+        api_server, created = ApiServer.objects.get_or_create(
+            name=api_config["name"],
+            defaults={
+                "api_url": api_config["api_url"],
+                "api_token": api_config["api_token"],
+                "enabled": True,
+            },
+        )
+
+        status = "Created" if created else "Found existing"
+        self.stdout.write(f"  API Server: {api_server.name} ({status})")
+        return api_server
+
+    def _create_zone(self, config, api_server):
+        """Create or get DNS Zone with proper naming methods."""
+        domain = config["domain"]
+
+        zone, created = Zone.objects.get_or_create(
+            name=domain,
+            defaults={
+                "description": f"E2E Test Zone for {domain}",
+                "enabled": True,
+                "default_ttl": 300,
+                "naming_ip_method": "netbox_powerdns_sync.naming.NamingIpDnsName",
+                "naming_device_method": "netbox_powerdns_sync.naming.NamingDeviceName",
+                "naming_fgrpgroup_method": "netbox_powerdns_sync.naming.NamingFGRPGroupName",
+            },
+        )
+
+        # Update naming methods if zone existed but was misconfigured
+        if not created and not zone.naming_device_method:
+            zone.naming_device_method = "netbox_powerdns_sync.naming.NamingDeviceName"
+            zone.naming_ip_method = "netbox_powerdns_sync.naming.NamingIpDnsName"
+            zone.save()
+            self.stdout.write(f"  Zone: {zone.name} (Updated naming methods)")
+        else:
+            status = "Created" if created else "Found existing"
+            self.stdout.write(f"  Zone: {zone.name} ({status})")
+
+        # Link API server to zone
+        if api_server not in zone.api_servers.all():
+            zone.api_servers.add(api_server)
+            self.stdout.write(f"    Linked to API Server: {api_server.name}")
+
+        return zone
+
+    def _create_site(self, config):
+        """Create test site."""
+        name = f"{config['prefix']}-site"
+        site, created = Site.objects.get_or_create(
+            name=name,
+            defaults={"slug": name, "status": "active"},
+        )
+        if created and self.verbosity >= 2:
+            self.stdout.write(f"  Site: {site.name}")
+        return site
+
+    def _create_manufacturer(self, config):
+        """Create test manufacturer."""
+        name = f"{config['prefix']}-manufacturer"
+        manufacturer, created = Manufacturer.objects.get_or_create(
+            name=name,
+            defaults={"slug": name},
+        )
+        if created and self.verbosity >= 2:
+            self.stdout.write(f"  Manufacturer: {manufacturer.name}")
+        return manufacturer
+
+    def _create_device_role(self, config):
+        """Create test device role."""
+        name = f"{config['prefix']}-role"
+        role, created = DeviceRole.objects.get_or_create(
+            name=name,
+            defaults={"slug": name, "color": "4caf50"},
+        )
+        if created and self.verbosity >= 2:
+            self.stdout.write(f"  DeviceRole: {role.name}")
+        return role
+
+    def _create_device_type(self, config, manufacturer):
+        """Create test device type."""
+        model = f"{config['prefix']}-server"
+        device_type, created = DeviceType.objects.get_or_create(
+            manufacturer=manufacturer,
+            model=model,
+            defaults={"slug": model},
+        )
+        if created and self.verbosity >= 2:
+            self.stdout.write(f"  DeviceType: {device_type.model}")
+        return device_type
+
+    def _create_devices(self, config, site, role, device_type):
+        """Create test devices with interfaces and IPs."""
+        domain = config["domain"].rstrip(".")
+        network = config["network"]
+        prefix = config["prefix"]
+
+        devices_config = [
+            {"name": f"{prefix}-server01.{domain}", "ip": f"{network}.1/24", "iface": "eth0"},
+            {"name": f"{prefix}-server02.{domain}", "ip": f"{network}.2/24", "iface": "eth0"},
+            {"name": f"{prefix}-db01.{domain}", "ip": f"{network}.10/24", "iface": "ens192"},
+        ]
+
+        devices = []
+        for dev_cfg in devices_config:
+            device, created = Device.objects.get_or_create(
+                name=dev_cfg["name"],
+                defaults={
+                    "site": site,
+                    "role": role,
+                    "device_type": device_type,
+                    "status": "active",
+                },
+            )
+            devices.append(device)
+
+            # Create interface
+            interface, _ = Interface.objects.get_or_create(
+                device=device,
+                name=dev_cfg["iface"],
+                defaults={"type": "1000base-t"},
+            )
+
+            # Create IP and assign to interface
+            ip, ip_created = IPAddress.objects.get_or_create(
+                address=dev_cfg["ip"],
+                defaults={
+                    "status": "active",
+                    "dns_name": dev_cfg["name"],
+                },
+            )
+            if ip_created or ip.assigned_object != interface:
+                ip.assigned_object = interface
+                ip.save()
+
+            # Refresh to get proper address object
+            ip.refresh_from_db()
+
+            # Set as primary IP (IPv4 only)
+            if ip.family == 4 and device.primary_ip4_id != ip.pk:
+                device.primary_ip4 = ip
+                device.save()
+
+            if self.verbosity >= 2:
+                status = "Created" if created else "Found"
+                self.stdout.write(f"  Device: {device.name} - {dev_cfg['ip']} ({status})")
+
+        return devices
+
+    def _create_vms(self, config, site):
+        """Create test VMs with interfaces and IPs."""
+        domain = config["domain"].rstrip(".")
+        network = config["network"]
+        prefix = config["prefix"]
+
+        # Create cluster infrastructure
+        cluster_type, _ = ClusterType.objects.get_or_create(
+            name=f"{prefix}-cluster-type",
+            defaults={"slug": f"{prefix}-cluster-type"},
+        )
+        cluster, _ = Cluster.objects.get_or_create(
+            name=f"{prefix}-cluster",
+            defaults={"type": cluster_type},
+        )
+
+        vms_config = [
+            {"name": f"{prefix}-web01.{domain}", "ip": f"{network}.100/24", "iface": "eth0"},
+            {"name": f"{prefix}-web02.{domain}", "ip": f"{network}.101/24", "iface": "eth0"},
+            {"name": f"{prefix}-app01.{domain}", "ip": f"{network}.110/24", "iface": "ens18"},
+        ]
+
+        vms = []
+        for vm_cfg in vms_config:
+            vm, created = VirtualMachine.objects.get_or_create(
+                name=vm_cfg["name"],
+                defaults={
+                    "cluster": cluster,
+                    "site": site,
+                    "status": "active",
+                },
+            )
+            vms.append(vm)
+
+            # Create VM interface
+            vminterface, _ = VMInterface.objects.get_or_create(
+                virtual_machine=vm,
+                name=vm_cfg["iface"],
+            )
+
+            # Create IP and assign to VM interface
+            ip, ip_created = IPAddress.objects.get_or_create(
+                address=vm_cfg["ip"],
+                defaults={
+                    "status": "active",
+                    "dns_name": vm_cfg["name"],
+                },
+            )
+            if ip_created or ip.assigned_object != vminterface:
+                ip.assigned_object = vminterface
+                ip.save()
+
+            # Refresh to get proper address object
+            ip.refresh_from_db()
+
+            # Set as primary IP (IPv4 only)
+            if ip.family == 4 and vm.primary_ip4_id != ip.pk:
+                vm.primary_ip4 = ip
+                vm.save()
+
+            if self.verbosity >= 2:
+                status = "Created" if created else "Found"
+                self.stdout.write(f"  VM: {vm.name} - {vm_cfg['ip']} ({status})")
+
+        return vms
+
+    def _create_standalone_ips(self, config):
+        """Create standalone IPs with dns_name (not assigned to any device)."""
+        domain = config["domain"].rstrip(".")
+        network = config["network"]
+        prefix = config["prefix"]
+
+        ips_config = [
+            {"dns_name": f"{prefix}-api.{domain}", "ip": f"{network}.200/24"},
+            {"dns_name": f"{prefix}-cdn.{domain}", "ip": f"{network}.201/24"},
+            {"dns_name": f"{prefix}-mail.{domain}", "ip": f"{network}.202/24"},
+        ]
+
+        ips = []
+        for ip_cfg in ips_config:
+            ip, created = IPAddress.objects.get_or_create(
+                address=ip_cfg["ip"],
+                defaults={
+                    "status": "active",
+                    "dns_name": ip_cfg["dns_name"],
+                },
+            )
+            if not created and ip.dns_name != ip_cfg["dns_name"]:
+                ip.dns_name = ip_cfg["dns_name"]
+                ip.save()
+
+            ips.append(ip)
+
+            if self.verbosity >= 2:
+                status = "Created" if created else "Found"
+                self.stdout.write(f"  Standalone IP: {ip_cfg['dns_name']} - {ip_cfg['ip']} ({status})")
+
+        return ips
+
+    def _trigger_sync(self, zone):
+        """Trigger a PowerDNS sync for the zone."""
+        self.stdout.write(f"\nTriggering sync for zone: {zone.name}")
+
+        User = get_user_model()
+        user = User.objects.first()
+
+        try:
+            Job.enqueue(
+                PowerdnsTaskFullSync.run_full_sync,
+                name=f"E2E Bootstrap Sync - {zone.name}",
+                user=user,
+                zone_id=zone.pk,
+            )
+            self.stdout.write(self.style.SUCCESS("  Sync job enqueued! Check worker logs."))
+        except Exception as e:
+            self.stdout.write(self.style.ERROR(f"  Failed to enqueue sync: {e}"))

--- a/netbox_powerdns_sync/models.py
+++ b/netbox_powerdns_sync/models.py
@@ -1,11 +1,10 @@
 import powerdns
-from django.contrib.contenttypes.models import ContentType
 from django.core.validators import MinLengthValidator
 from django.db import models
 from django.forms import ValidationError
 from django.urls import reverse
 from taggit.managers import TaggableManager
-from core.models import Job
+from core.models import Job, ObjectType
 from dcim.models import DeviceRole, Interface
 from ipam.models import IPAddress, FHRPGroup
 from netbox.models import NetBoxModel
@@ -210,7 +209,7 @@ class Zone(NetBoxModel):
         # delete any scheduled jobs for this zone
         if self.pk:
             jobs = Job.objects.filter(
-                object_type_id=ContentType.objects.get_for_model(self).pk,
+                object_type_id=ObjectType.objects.get_for_model(self).pk,
                 object_id=self.pk,
                 status="scheduled",
                 name=JOB_NAME_SYNC

--- a/netbox_powerdns_sync/models.py
+++ b/netbox_powerdns_sync/models.py
@@ -208,11 +208,10 @@ class Zone(NetBoxModel):
     def delete(self, *args, **kwargs):
         # delete any scheduled jobs for this zone
         if self.pk:
+            # Since we use zone_id instead of instance, search by name pattern
             jobs = Job.objects.filter(
-                object_type_id=ObjectType.objects.get_for_model(self).pk,
-                object_id=self.pk,
                 status="scheduled",
-                name=JOB_NAME_SYNC
+                name__startswith=f"{JOB_NAME_SYNC} - {self.name}"
             )
             jobs.delete()
         return super().delete(*args, **kwargs)

--- a/netbox_powerdns_sync/naming.py
+++ b/netbox_powerdns_sync/naming.py
@@ -39,6 +39,8 @@ def generate_fqdn(ip: IPAddress, zone: Zone) -> str | None:
         method = getattr(zone, method_attr, None)
         if method:
             klass = _load_class(method)
+            if klass is None:
+                continue
             naming_method = klass(ip, zone)
             fqdn = naming_method.make_fqdn()
             if fqdn:

--- a/netbox_powerdns_sync/navigation.py
+++ b/netbox_powerdns_sync/navigation.py
@@ -1,5 +1,4 @@
-from extras.plugins import PluginMenuItem, PluginMenuButton
-from utilities.choices import ButtonColorChoices
+from netbox.plugins import PluginMenuItem, PluginMenuButton
 
 
 apiserver_buttons = [
@@ -7,7 +6,6 @@ apiserver_buttons = [
         link='plugins:netbox_powerdns_sync:apiserver_add',
         title='Add',
         icon_class='mdi mdi-plus-thick',
-        color=ButtonColorChoices.GREEN
     ),
 ]
 
@@ -16,7 +14,6 @@ zone_buttons = [
         link='plugins:netbox_powerdns_sync:zone_add',
         title='Add',
         icon_class='mdi mdi-plus-thick',
-        color=ButtonColorChoices.GREEN
     ),
 ]
 

--- a/netbox_powerdns_sync/signals.py
+++ b/netbox_powerdns_sync/signals.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_save
 
 from core.models import Job
 from dcim.models import Device, Interface
-from extras.plugins.utils import get_plugin_config
+from netbox.plugins.utils import get_plugin_config
 from ipam.models import IPAddress, FHRPGroup
 from netbox.context import current_request
 from virtualization.models import VirtualMachine, VMInterface

--- a/netbox_powerdns_sync/tables.py
+++ b/netbox_powerdns_sync/tables.py
@@ -15,18 +15,16 @@ SYNC_URL_ID = """<a href="{% url 'plugins:netbox_powerdns_sync:sync_result' job_
 SYNC_URL_NAME = """<a href="{% url 'plugins:netbox_powerdns_sync:sync_result' job_pk=record.id %}">{{ value }}</a>"""
 DEVICE_ROLE_COLUMN = """
 {% for role in value.all %}
-    <span class="badge" style="color: {{ role.color|fgcolor }}; background-color: #{{ role.color }}">
-        <a href="{{ role.get_absolute_url }}">{{ role }}</a>
-    </span>
+    {% include 'inc/badge.html' with label=role color=role.color url=role.get_absolute_url %}
 {% endfor %}
 """
 ZONE_EXTRA_BUTTONS = """
 {% if record.enabled %}
-    <a href="{% url 'plugins:netbox_powerdns_sync:sync_schedule' %}?zones={{ record.pk }}" class="btn btn-sm btn-primary" title="Schedule full sync for zone">
+    <a href="{% url 'plugins:netbox_powerdns_sync:sync_schedule' %}?zones={{ record.pk }}" class="btn btn-primary" title="Schedule full sync for zone">
         <span class="mdi mdi-sync" aria-hidden="true"></span>
     </a>
 {% else %}
-    <a href="#" class="btn btn-sm btn-primary disabled" title="Schedule full sync for zone">
+    <a href="#" class="btn btn-primary disabled" title="Schedule full sync for zone">
         <span class="mdi mdi-sync" aria-hidden="true"></span>
     </a>
 {% endif %}

--- a/netbox_powerdns_sync/templates/netbox_powerdns_sync/htmx/sync_result.html
+++ b/netbox_powerdns_sync/templates/netbox_powerdns_sync/htmx/sync_result.html
@@ -4,11 +4,11 @@
 
 <p>
   {% if job.started %}
-    Started: <strong>{{ job.started|annotated_date }}</strong>
+    Started: <strong>{{ job.started|isodatetime }}</strong>
   {% elif job.scheduled %}
-    Scheduled for: <strong>{{ job.scheduled|annotated_date }}</strong> ({{ job.scheduled|naturaltime }})
+    Scheduled for: <strong>{{ job.scheduled|isodatetime }}</strong> ({{ job.scheduled|naturaltime }})
   {% else %}
-    Created: <strong>{{ job.created|annotated_date }}</strong>
+    Created: <strong>{{ job.created|isodatetime }}</strong>
   {% endif %}
   {% if job.completed %}
     Duration: <strong>{{ job.duration }}</strong>

--- a/netbox_powerdns_sync/templates/netbox_powerdns_sync/sync_result.html
+++ b/netbox_powerdns_sync/templates/netbox_powerdns_sync/sync_result.html
@@ -11,7 +11,7 @@
       <nav class="breadcrumb-container px-3" aria-label="breadcrumb">
         <ol class="breadcrumb">
           <li class="breadcrumb-item"><a href="{% url 'plugins:netbox_powerdns_sync:sync_jobs' %}">Sync Jobs</a></li>
-          <li class="breadcrumb-item">{{ job.created|annotated_date }}</li>
+          <li class="breadcrumb-item">{{ job.created|isodatetime }}</li>
         </ol>
       </nav>
     </div>

--- a/netbox_powerdns_sync/templates/netbox_powerdns_sync/syncs.html
+++ b/netbox_powerdns_sync/templates/netbox_powerdns_sync/syncs.html
@@ -8,7 +8,7 @@
 {% block controls %}
   <div class="controls">
     <div class="control-group">
-      <a href="{% url 'plugins:netbox_powerdns_sync:sync_schedule' %}" type="button" class="btn btn-sm btn-primary" title="Schedule full zone sync">
+      <a href="{% url 'plugins:netbox_powerdns_sync:sync_schedule' %}" type="button" class="btn btn-primary" title="Schedule full zone sync">
         <i class="mdi mdi-clock-outline" aria-hidden="true"></i> Schedule
       </a>
     </div>

--- a/netbox_powerdns_sync/templates/netbox_powerdns_sync/zone.html
+++ b/netbox_powerdns_sync/templates/netbox_powerdns_sync/zone.html
@@ -5,11 +5,11 @@
 
 {% block extra_controls %}
   {% if object.enabled %}
-    <a href="{% url 'plugins:netbox_powerdns_sync:sync_schedule' %}?zones={{ object.pk }}" class="btn btn-sm btn-primary">
+    <a href="{% url 'plugins:netbox_powerdns_sync:sync_schedule' %}?zones={{ object.pk }}" class="btn btn-primary">
       <span class="mdi mdi-sync" aria-hidden="true"></span> Schedule Sync
     </a>
   {% else %}
-    <a href="#" class="btn btn-sm btn-primary disabled">
+    <a href="#" class="btn btn-primary disabled">
       <span class="mdi mdi-sync" aria-hidden="true"></span> Schedule Sync
     </a>
   {% endif %}

--- a/netbox_powerdns_sync/utils.py
+++ b/netbox_powerdns_sync/utils.py
@@ -2,10 +2,10 @@ import re
 import unicodedata
 
 from dcim.models import Device, Interface
-from django.contrib.contenttypes.models import ContentType
-from extras.choices import ObjectChangeActionChoices
-from extras.models import ObjectChange
-from extras.plugins.utils import get_plugin_config
+from django.db.models import Q
+from core.choices import ObjectChangeActionChoices
+from core.models import ObjectChange, ObjectType
+from netbox.plugins.utils import get_plugin_config
 from ipam.models import IPAddress
 from powerdns import Comment, RRSet
 from virtualization.models import VirtualMachine, VMInterface
@@ -113,7 +113,7 @@ def find_objectchange_ip(ip, request_id):
     return ObjectChange.objects.filter(
         action=ObjectChangeActionChoices.ACTION_CREATE,
         request_id=request_id,
-        changed_object_type=ContentType.objects.get_for_model(ip),
+        changed_object_type=ObjectType.objects.get_for_model(ip),
         changed_object_id=ip.pk,
     )
 

--- a/netbox_powerdns_sync/views/api_servers.py
+++ b/netbox_powerdns_sync/views/api_servers.py
@@ -1,5 +1,5 @@
 from netbox.views import generic
-from utilities.utils import count_related
+from utilities.query import count_related
 from utilities.views import register_model_view
 
 from .. import filtersets, forms, tables

--- a/netbox_powerdns_sync/views/syncs.py
+++ b/netbox_powerdns_sync/views/syncs.py
@@ -53,12 +53,18 @@ class SyncJobsView(ContentTypePermissionRequiredMixin, View):
         return "extras.view_script"
 
     def get(self, request):
-        query = Q(app_label="netbox_powerdns_sync", model="zone")|Q(app_label="ipam", model="ipaddress")
+        # Filter jobs by object_type OR by name pattern (for jobs without instance)
+        query = Q(app_label="netbox_powerdns_sync", model="zone") | Q(app_label="ipam", model="ipaddress")
         object_types = ObjectType.objects.filter(query)
+
+        # Jobs with object_type (legacy) OR jobs matching our name patterns
+        # Include various sync job name patterns
         jobs = Job.objects.filter(
-            object_type__in=object_types,
-            name__in=(JOB_NAME_DEVICE, JOB_NAME_INTERFACE, JOB_NAME_IP, JOB_NAME_SYNC),
-        )
+            Q(object_type__in=object_types) |
+            Q(name__startswith=JOB_NAME_SYNC) |
+            Q(name__icontains="Sync") |  # Catch "Test Sync", "E2E Bootstrap Sync", etc.
+            Q(name__in=(JOB_NAME_DEVICE, JOB_NAME_INTERFACE, JOB_NAME_IP))
+        ).order_by("-created")
         jobs_table = SyncJobTable(
             data=jobs,
             orderable=False,
@@ -130,8 +136,8 @@ class SyncScheduleView(View):
             for zone in form.cleaned_data["zones"]:
                 Job.enqueue(
                     PowerdnsTaskFullSync.run_full_sync,
-                    instance=zone,
-                    name=JOB_NAME_SYNC,
+                    zone_id=zone.pk,
+                    name=f"{JOB_NAME_SYNC} - {zone.name}",
                     user=request.user,
                     schedule_at=form.cleaned_data.get("_schedule_at"),
                     interval=form.cleaned_data.get("_interval"),

--- a/netbox_powerdns_sync/views/syncs.py
+++ b/netbox_powerdns_sync/views/syncs.py
@@ -1,13 +1,11 @@
 from django.contrib import messages
-from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.generic import View
-from core.models import Job
-from utilities.htmx import is_htmx
+from core.models import Job, ObjectType
 from utilities.rqworker import get_workers_for_queue
-from utilities.utils import normalize_querydict
+from utilities.querydict import normalize_querydict
 from utilities.views import ContentTypePermissionRequiredMixin
 
 from ..constants import JOB_NAME_DEVICE, JOB_NAME_INTERFACE, JOB_NAME_IP, JOB_NAME_SYNC
@@ -56,7 +54,7 @@ class SyncJobsView(ContentTypePermissionRequiredMixin, View):
 
     def get(self, request):
         query = Q(app_label="netbox_powerdns_sync", model="zone")|Q(app_label="ipam", model="ipaddress")
-        object_types = ContentType.objects.filter(query)
+        object_types = ObjectType.objects.filter(query)
         jobs = Job.objects.filter(
             object_type__in=object_types,
             name__in=(JOB_NAME_DEVICE, JOB_NAME_INTERFACE, JOB_NAME_IP, JOB_NAME_SYNC),
@@ -88,7 +86,7 @@ class SyncResultView(ContentTypePermissionRequiredMixin, View):
         #script = module.scripts[job.name]()
 
         # If this is an HTMX request, return only the result HTML
-        if is_htmx(request):
+        if request.htmx:
             response = render(request, "netbox_powerdns_sync/htmx/sync_result.html", {
                 #"script": script,
                 "job": job,

--- a/netbox_powerdns_sync/views/zones.py
+++ b/netbox_powerdns_sync/views/zones.py
@@ -1,5 +1,5 @@
 from netbox.views import generic
-from utilities.utils import count_related
+from utilities.query import count_related
 from utilities.views import register_model_view
 
 from .. import filtersets, forms, tables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ include = ["netbox_powerdns_sync/templates/*.html"]
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-python-powerdns = "^2.1.0"
+python-powerdns = ">=2.1.0"
+django = ">=5.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.3.0"


### PR DESCRIPTION
Migrate plugin to netboxv4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Breaking: bumps minimum NetBox to `4.4.0` and adds `django>=5.0`.
> 
> - NetBox v4 migration: replace deprecated imports (`extras.plugins`→`netbox.plugins`, `ContentType`→`core.models.ObjectType`, utilities moves), update serializers to `TagSerializer`/`DeviceRoleSerializer`, and UI template/controls tweaks (buttons, `isodatetime`).
> - Jobs rework: full sync now enqueued with `zone_id` (no `instance`), scheduling/naming updated, deletion of scheduled jobs by name prefix, HTMX check via `request.htmx`, and Sync Jobs view filters by `ObjectType`/name patterns.
> - PDNS/records: fix M2M query (`zone.api_servers.filter(enabled=True)`), guard against missing FQDN, use forward zone TTL for A/AAAA, and improve reverse record data canonicalization.
> - Forms/tables/nav: switch to `FieldSet`, badge includes, and plugin menu imports.
> - New: `bootstrap_e2e` management command to create test data and enqueue a zone sync; add `ARCHITECTURE.md` with architecture, pitfalls, and v4 notes.
> - Dependencies: loosen `python-powerdns>=2.1.0`, add `django>=5.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f553cf34385f53ef68fb6b2da72916789c4151b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->